### PR TITLE
remove unresolved symlinks

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -364,12 +364,10 @@ run_scanner() {
         -v "${VOLUME_NAME}:/project" \
         --name="temp_${PROJECT_NAME}" \
         busybox > /dev/null
+    echo-notice "Removing unresolved symlinks..."
+    docker exec "temp_${PROJECT_NAME}" sh -c 'find /project -type l -exec test ! {} \; -print -delete'
     docker cp ${PROJECT_DIRECTORY} "temp_${PROJECT_NAME}":/project > /dev/null
     docker rm -f "temp_${PROJECT_NAME}" >/dev/null
-
-    echo-notice "Removing unresolved symlinks (which can cause the scanner to fail)..."
-    docker run --rm -it -v "${VOLUME_NAME}:/project" \
-        alpine find project/${PROJECT_NAME} -type l -exec test ! -e {} \; -print -delete
 
     # Run the Scanner
     echo-notice "Running Scanner..."

--- a/run.sh
+++ b/run.sh
@@ -367,6 +367,10 @@ run_scanner() {
     docker cp ${PROJECT_DIRECTORY} "temp_${PROJECT_NAME}":/project > /dev/null
     docker rm -f "temp_${PROJECT_NAME}" >/dev/null
 
+    echo-notice "Removing unresolved symlinks (which can cause the scanner to fail)..."
+    docker run --rm -it -v "${VOLUME_NAME}:/project" \
+        alpine find project/${PROJECT_NAME} -type l -exec test ! -e {} \; -print -delete
+
     # Run the Scanner
     echo-notice "Running Scanner..."
     echo-warning "This process can take a decent amount of time..."


### PR DESCRIPTION
## Description
https://kanopi.teamwork.com/app/tasks/29746447

Remove unresolved symlinks before running scanner.

## Steps to Validate
1. Run scanner against https://github.com/kanopi/nptrust -- it has two unresolved symlinks: `project/npt2/web/wp-content/cache` & `project/npt2/web/wp-content/wflogs` which cause the scanner to crash.
2. `bash ~/projects/security-reports/run.sh run` should show you a `Removing unresolved symlinks` notice
3. The symlinks should be removed. I tested with adding an additional step in the script to list the directory content where the links were located, see below, but do whatever makes sense.
```
    echo-notice "Are the symlinks gone?"
    docker run --rm -it -v "${VOLUME_NAME}:/project" \
        alpine ls project/${PROJECT_NAME}/web/wp-content
```
